### PR TITLE
Changed all to history

### DIFF
--- a/store.go
+++ b/store.go
@@ -84,5 +84,5 @@ func (m *memoryStore) Load(ctx context.Context, aggregateID string, fromVersion,
 		}
 	}
 
-	return all, nil
+	return history, nil
 }


### PR DESCRIPTION
I changed the all to history in the return of the Load method as always returning all would never load records in between if one wanted to.